### PR TITLE
Fix the vet command for more modern go.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ check-go:
 		echo go fmt is sad: $(GOFMT); \
 		exit 1; \
 	fi )
-	@(go tool vet -all -composites=false -copylocks=false .)
+	@(go vet -all -composites=false -copylocks=false $(PROJECT)/...)


### PR DESCRIPTION
Go 1.14 complains about using "go tool vet" and suggests "go vet". Also update the path ti calls.