### PR TITLE
Adds SliceToMap to transform package

### DIFF
--- a/transform/package_test.go
+++ b/transform/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package transform
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/transform/slice.go
+++ b/transform/slice.go
@@ -12,3 +12,15 @@ func Slice[F any, T any](from []F, transform func(F) T) []T {
 	}
 	return to
 }
+
+// SliceToMap transforms a slice of one type to an equal length
+// map with values from the slice, keyed by values indicated by
+// the input transformation function.
+func SliceToMap[F any, K comparable, V any](from []F, transform func(F) (K, V)) map[K]V {
+	to := make(map[K]V, len(from))
+	for _, oneFrom := range from {
+		k, v := transform(oneFrom)
+		to[k] = v
+	}
+	return to
+}

--- a/transform/slice_test.go
+++ b/transform/slice_test.go
@@ -15,7 +15,7 @@ type sliceSuite struct {
 
 var _ = gc.Suite(sliceSuite{})
 
-func (sliceSuite) TestSimpleTransformation(c *gc.C) {
+func (sliceSuite) TestSliceTransformation(c *gc.C) {
 	type this struct {
 		number int
 	}
@@ -37,4 +37,28 @@ func (sliceSuite) TestSimpleTransformation(c *gc.C) {
 	}
 
 	c.Assert(transform.Slice(from, thisToThat), gc.DeepEquals, to)
+}
+
+func (sliceSuite) TestSliceToMapTransformation(c *gc.C) {
+	type this struct {
+		number int
+	}
+
+	type that struct {
+		numero int
+	}
+
+	from := []this{
+		{number: 1},
+		{number: 2},
+	}
+
+	thisToThat := func(from this) (int, that) { return from.number, that{numero: from.number} }
+
+	to := map[int]that{
+		1: {numero: 1},
+		2: {numero: 2},
+	}
+
+	c.Assert(transform.SliceToMap(from, thisToThat), gc.DeepEquals, to)
 }


### PR DESCRIPTION
Introduce the `SliceToMap` function to the `transform` package.

It is useful for transforming a slice to an equal length map, with keys derived from the slice members, and values as the actual slice members.