### PR TITLE
Implement SliceOrErr

### DIFF
--- a/transform/slice.go
+++ b/transform/slice.go
@@ -3,6 +3,10 @@
 
 package transform
 
+import (
+	"github.com/juju/errors"
+)
+
 // Slice transforms a slice of one type to an equal length slice of another,
 // by applying the input transformation function to each member.
 func Slice[F any, T any](from []F, transform func(F) T) []T {
@@ -11,6 +15,22 @@ func Slice[F any, T any](from []F, transform func(F) T) []T {
 		to[i] = transform(oneFrom)
 	}
 	return to
+}
+
+// SliceOrErr transforms a slice from one type to an equal length slice of another
+// by mapping the input transformation function to each member.
+// SliceOrErr supports transformations that can error. If an error is encountered, the
+// mapping will be cancelled and the error returned
+func SliceOrErr[F any, T any](from []F, transform func(F) (T, error)) ([]T, error) {
+	to := make([]T, len(from))
+	for i, oneFrom := range from {
+		var err error
+		to[i], err = transform(oneFrom)
+		if err != nil {
+			return nil, errors.Annotatef(err, "error encountered transforming slice at index %d", i)
+		}
+	}
+	return to, nil
 }
 
 // SliceToMap transforms a slice of one type to an equal length

--- a/transform/slice_test.go
+++ b/transform/slice_test.go
@@ -5,6 +5,7 @@ package transform_test
 
 import (
 	"github.com/juju/collections/transform"
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 )
@@ -37,6 +38,58 @@ func (sliceSuite) TestSliceTransformation(c *gc.C) {
 	}
 
 	c.Assert(transform.Slice(from, thisToThat), gc.DeepEquals, to)
+}
+
+func (sliceSuite) TestSliceOrErrTransformationSucceeds(c *gc.C) {
+	type this struct {
+		number int
+	}
+
+	type that struct {
+		numero int
+	}
+
+	from := []this{
+		{number: 1},
+		{number: 2},
+	}
+
+	thisToThat := func(from this) (that, error) { return that{numero: from.number}, nil }
+
+	to := []that{
+		{numero: 1},
+		{numero: 2},
+	}
+
+	res, err := transform.SliceOrErr(from, thisToThat)
+	c.Assert(err, gc.IsNil)
+	c.Assert(res, gc.DeepEquals, to)
+}
+
+func (sliceSuite) TestSliceOrErrTransformationErrors(c *gc.C) {
+	type this struct {
+		number int
+	}
+
+	type that struct {
+		numero int
+	}
+
+	from := []this{
+		{number: 1},
+		{number: 0},
+		{number: 2},
+	}
+
+	thisToThat := func(from this) (that, error) {
+		if from.number == 0 {
+			return that{}, errors.New("cannot transform 0")
+		}
+		return that{numero: from.number}, nil
+	}
+
+	_, err := transform.SliceOrErr(from, thisToThat)
+	c.Assert(err, gc.ErrorMatches, "error encountered transforming slice at index 1: cannot transform 0")
 }
 
 func (sliceSuite) TestSliceToMapTransformation(c *gc.C) {


### PR DESCRIPTION
Sometimes I have found I have wanted to use transform.Slice, but have been unable to because of the potential for the transform function to fail

So I have implemented a similar helper function which supports erroring when transforming