### PR TITLE
Map transform

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/juju/testing v1.0.2
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 )
 
@@ -16,7 +17,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/transform/map.go
+++ b/transform/map.go
@@ -3,6 +3,20 @@
 
 package transform
 
+// Map transforms a map of one type to a map of another, by applying the input
+// transformation function to each key value pair.
+func Map[K comparable, V any, Kn comparable, Vn any](
+	from map[K]V,
+	transform func(K, V) (Kn, Vn),
+) map[Kn]Vn {
+	to := make(map[Kn]Vn, len(from))
+	for k, v := range from {
+		kn, vn := transform(k, v)
+		to[kn] = vn
+	}
+	return to
+}
+
 // MapToSlice is responsible for flattening a map of key values into a
 // contiguous slice of key value pares from the map.
 func MapToSlice[K comparable, V, T any](from map[K]V, transform func(K, V) []T) []T {

--- a/transform/map_test.go
+++ b/transform/map_test.go
@@ -46,3 +46,32 @@ func (mapSuite) TestMapToSlice(c *C) {
 	slices.Sort(to)
 	c.Assert(to, DeepEquals, []string{"a", "b", "c", "d"})
 }
+
+func (mapSuite) TestEmptyMapTransformEmpty(c *C) {
+	m := map[string]string{}
+
+	to := transform.Map(m, func(k, v string) (string, any) {
+		return k, v
+	})
+
+	c.Assert(len(to), Equals, 0)
+}
+
+func (mapSuite) TestEmptyMapTransform(c *C) {
+	m := map[string]string{
+		"one":   "two",
+		"three": "four",
+	}
+
+	to := transform.Map(m, func(k, v string) (string, int) {
+		if v == "two" {
+			return k, 2
+		}
+		return k, 4
+	})
+
+	c.Assert(to, DeepEquals, map[string]int{
+		"one":   2,
+		"three": 4,
+	})
+}

--- a/transform/slice.go
+++ b/transform/slice.go
@@ -4,7 +4,7 @@
 package transform
 
 import (
-	"github.com/juju/errors"
+	"fmt"
 )
 
 // Slice transforms a slice of one type to an equal length slice of another,
@@ -27,7 +27,7 @@ func SliceOrErr[F any, T any](from []F, transform func(F) (T, error)) ([]T, erro
 		var err error
 		to[i], err = transform(oneFrom)
 		if err != nil {
-			return nil, errors.Annotatef(err, "error encountered transforming slice at index %d", i)
+			return nil, fmt.Errorf("transforming slice at index %d: %w", i, err)
 		}
 	}
 	return to, nil

--- a/transform/slice_test.go
+++ b/transform/slice_test.go
@@ -4,10 +4,12 @@
 package transform_test
 
 import (
-	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
+	"errors"
+
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/collections/transform"
 )
 
 type sliceSuite struct {
@@ -81,15 +83,17 @@ func (sliceSuite) TestSliceOrErrTransformationErrors(c *gc.C) {
 		{number: 2},
 	}
 
+	testErr := errors.New("cannot transform 0")
 	thisToThat := func(from this) (that, error) {
 		if from.number == 0 {
-			return that{}, errors.New("cannot transform 0")
+			return that{}, testErr
 		}
 		return that{numero: from.number}, nil
 	}
 
 	_, err := transform.SliceOrErr(from, thisToThat)
-	c.Assert(err, gc.ErrorMatches, "error encountered transforming slice at index 1: cannot transform 0")
+	c.Assert(errors.Is(err, testErr), gc.Equals, true)
+	c.Assert(err, gc.ErrorMatches, "transforming slice at index 1: cannot transform 0")
 }
 
 func (sliceSuite) TestSliceToMapTransformation(c *gc.C) {


### PR DESCRIPTION

- Adds a map transform function for going from one set of types to a new set of types
- Removes direct usage of Juju errors in favor of go errors as it covers our simple cases very well and we can drop the implicit dependency.